### PR TITLE
Replace customer terminology with property

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -324,7 +324,7 @@ const classifyAccount = (accountType, accountDetailType, accountName) => {
 
 // Hardcoded customers based on actual database data
 const HARDCODED_CUSTOMERS = [
-  "All Customers",
+  "All Properties",
   "Cleveland",
   "Columbus IN",
   "Detroit",
@@ -362,15 +362,15 @@ const fetchCustomers = async () => {
     const allCustomers = [
       ...new Set([...HARDCODED_CUSTOMERS.slice(1), ...uniqueCustomers]),
     ].sort()
-    return ["All Customers", ...allCustomers]
+    return ["All Properties", ...allCustomers]
   } catch (error) {
     console.error("❌ Customer fetch error:", error)
     return HARDCODED_CUSTOMERS
   }
 }
 
-// ENHANCED: Time series data fetching with Customer Dimension support
-const fetchTimeSeriesData = async (property = "All Customers", monthYear, timePeriod, viewMode, onDataValidation) => {
+// ENHANCED: Time series data fetching with Property Dimension support
+const fetchTimeSeriesData = async (property = "All Properties", monthYear, timePeriod, viewMode, onDataValidation) => {
   try {
     const perfStart = performanceTracker.startTime("fetchTimeSeriesData")
     smartLog("🔍 FETCHING TIME SERIES DATA:", { property, monthYear, timePeriod, viewMode })
@@ -588,7 +588,7 @@ const fetchTimeSeriesData = async (property = "All Customers", monthYear, timePe
 
       // FIXED: For by-property view, NEVER filter by customer - we need ALL customer data
       // Only filter by customer for non-by-property views
-      if (viewMode !== "by-property" && property !== "All Customers") {
+      if (viewMode !== "by-property" && property !== "All Properties") {
         url += `&customer=eq.${encodeURIComponent(property)}`
       }
 
@@ -632,7 +632,7 @@ const fetchTimeSeriesData = async (property = "All Customers", monthYear, timePe
           // Group by account first, then by customer within each account
           const groupedByAccount = rawData.reduce((acc, row) => {
             const accountName = row.account || "Unknown Account"
-            const propertyName = row.customer || "No Customer"
+            const propertyName = row.customer || "No Property"
 
             const category = classifyAccount(row.account_type, row.account_detail_type, accountName)
             if (category === null) {
@@ -788,7 +788,7 @@ const fetchTimeSeriesData = async (property = "All Customers", monthYear, timePe
         summary: {
           timePeriod,
           viewMode,
-          property: property === "All Customers" ? "ALL CUSTOMERS" : property,
+          property: property === "All Properties" ? "ALL PROPERTIES" : property,
           dateRanges: [
             {
               start: dateRanges[0].start,
@@ -843,7 +843,7 @@ const fetchTimeSeriesData = async (property = "All Customers", monthYear, timePe
         summary: {
           timePeriod,
           viewMode,
-          property: property === "All Customers" ? "ALL CUSTOMERS" : property,
+          property: property === "All Properties" ? "ALL PROPERTIES" : property,
           dateRanges: [
             {
               start: dateRanges[0].start,
@@ -869,7 +869,7 @@ const fetchTimeSeriesData = async (property = "All Customers", monthYear, timePe
       summary: {
         timePeriod,
         viewMode,
-        property: property === "All Customers" ? "ALL CUSTOMERS" : property,
+        property: property === "All Properties" ? "ALL PROPERTIES" : property,
         dateRanges: dateRanges,
         totalEntriesProcessed,
         periodsGenerated: dateRanges.length,
@@ -936,7 +936,7 @@ export default function MobileResponsiveFinancialsPage() {
   const [viewMode, setViewMode] = useState("by-property") // Default to by-customer
   const [notification, setNotification] = useState({ show: false, message: "", type: "info" })
   const [timePeriodDropdownOpen, setTimePeriodDropdownOpen] = useState(false)
-  const [selectedProperties, setSelectedProperties] = useState(new Set(["All Customers"]))
+  const [selectedProperties, setSelectedProperties] = useState(new Set(["All Properties"]))
   const [propertyDropdownOpen, setPropertyDropdownOpen] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false)
@@ -969,8 +969,8 @@ export default function MobileResponsiveFinancialsPage() {
   // Mobile-specific states
   const [tableMode, setTableMode] = useState("summary") // Default to summary
   const [activeKPICard, setActiveKPICard] = useState(null)
-  const [selectedCustomerForPL, setSelectedCustomerForPL] = useState(null)
-  const [showCustomerPL, setShowCustomerPL] = useState(false)
+  const [selectedPropertyForPL, setSelectedPropertyForPL] = useState(null)
+  const [showPropertyPL, setShowPropertyPL] = useState(false)
   const [showTransactionDetail, setShowTransactionDetail] = useState(false)
   const [showCompanyPL, setShowCompanyPL] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
@@ -1036,20 +1036,20 @@ export default function MobileResponsiveFinancialsPage() {
                 value={viewMode}
                 onChange={(e) => setViewMode(e.target.value)}
               >
-                <option value="by-property">By Customer</option>
+                <option value="by-property">By Property</option>
                 <option value="total">Total</option>
                 <option value="detailed">Detailed</option>
               </select>
             </div>
 
-            {/* Customers multiselect */}
+            {/* Properties multiselect */}
             <div>
-              <div className="text-xs text-gray-600 mb-1">Customers</div>
+              <div className="text-xs text-gray-600 mb-1">Properties</div>
               <button
                 className="w-full rounded-md border px-3 py-2 text-sm text-left"
                 onClick={() => setPropertyDropdownOpen((v) => !v)}
               >
-                {getSelectedCustomersText()}
+                {getSelectedPropertiesText()}
               </button>
 
               {propertyDropdownOpen && (
@@ -1165,9 +1165,9 @@ export default function MobileResponsiveFinancialsPage() {
       setIsLoadingData(true)
       setDataError(null)
 
-      // FIXED: For by-property view, always use 'All Customers' to get all data
-      let propertyFilter = "All Customers"
-      if (viewMode !== "by-property" && selectedProperties.size > 0 && !selectedProperties.has("All Customers")) {
+      // FIXED: For by-property view, always use 'All Properties' to get all data
+      let propertyFilter = "All Properties"
+      if (viewMode !== "by-property" && selectedProperties.size > 0 && !selectedProperties.has("All Properties")) {
         propertyFilter = Array.from(selectedProperties)[0]
       }
 
@@ -1178,7 +1178,7 @@ export default function MobileResponsiveFinancialsPage() {
         timePeriod,
         viewMode,
         note:
-          viewMode === "by-property" ? "FORCING All Customers for by-customer view" : "Using selected customer filter",
+          viewMode === "by-property" ? "FORCING All Properties for by-customer view" : "Using selected customer filter",
       })
 
       const timeSeriesResult = await fetchTimeSeriesData(
@@ -1200,7 +1200,7 @@ export default function MobileResponsiveFinancialsPage() {
       const customerText =
         viewMode === "by-property"
           ? "all customers (by-customer view)"
-          : selectedProperties.has("All Customers")
+          : selectedProperties.has("All Properties")
             ? "all customers"
             : `${selectedProperties.size} selected customers`
 
@@ -1220,11 +1220,11 @@ export default function MobileResponsiveFinancialsPage() {
   const handlePropertyToggle = (property) => {
     const newSelected = new Set(selectedProperties)
 
-    if (property === "All Customers") {
+    if (property === "All Properties") {
       newSelected.clear()
-      newSelected.add("All Customers")
+      newSelected.add("All Properties")
     } else {
-      newSelected.delete("All Customers")
+      newSelected.delete("All Properties")
 
       if (newSelected.has(property)) {
         newSelected.delete(property)
@@ -1233,22 +1233,22 @@ export default function MobileResponsiveFinancialsPage() {
       }
 
       if (newSelected.size === 0) {
-        newSelected.add("All Customers")
+        newSelected.add("All Properties")
       }
     }
 
     setSelectedProperties(newSelected)
-    smartLog("🏠 Customer selection changed:", Array.from(newSelected))
+    smartLog("🏠 Property selection changed:", Array.from(newSelected))
   }
 
-  const getSelectedCustomersText = () => {
-    if (selectedProperties.has("All Customers") || selectedProperties.size === 0) {
-      return "All Customers"
+  const getSelectedPropertiesText = () => {
+    if (selectedProperties.has("All Properties") || selectedProperties.size === 0) {
+      return "All Properties"
     }
     if (selectedProperties.size === 1) {
       return Array.from(selectedProperties)[0]
     }
-    return `${selectedProperties.size} Customers Selected`
+    return `${selectedProperties.size} Properties Selected`
   }
 
   // Helper functions
@@ -1752,7 +1752,7 @@ export default function MobileResponsiveFinancialsPage() {
       .filter((item) => item.value > 0)
   }
 
-  const generateCustomerChartData = () => {
+  const generatePropertyChartData = () => {
     // Only show customer data if we have it
     if (viewMode === "by-property" && timeSeriesData?.availableProperties) {
       return timeSeriesData.availableProperties
@@ -1812,7 +1812,7 @@ export default function MobileResponsiveFinancialsPage() {
       currentData.forEach((account) => {
         if (account.entries) {
           account.entries.forEach((entry) => {
-            const property = entry.customer || "No Customer"
+            const property = entry.customer || "No Property"
             if (!propertyData[property]) {
               propertyData[property] = { revenue: 0, cogs: 0, opex: 0, otherIncome: 0, otherExpenses: 0 }
             }
@@ -1971,7 +1971,7 @@ export default function MobileResponsiveFinancialsPage() {
       achievements.push({
         id: "portfolio-powerhouse",
         title: "🌟 Portfolio Powerhouse",
-        description: `${profitableProperties.length} of ${propertyData.length} customers (${profitablePercentage.toFixed(0)}%) are profitable`,
+        description: `${profitableProperties.length} of ${propertyData.length} properties (${profitablePercentage.toFixed(0)}%) are profitable`,
         type: "info",
         metric: profitableProperties.length,
       })
@@ -1982,7 +1982,7 @@ export default function MobileResponsiveFinancialsPage() {
       achievements.push({
         id: "efficiency-expert",
         title: "⚡ Efficiency Expert",
-        description: `${highMarginProperties.length} customers achieve 20%+ profit margins`,
+        description: `${highMarginProperties.length} properties achieve 20%+ profit margins`,
         type: "info",
         metric: highMarginProperties.length,
       })
@@ -2005,7 +2005,7 @@ export default function MobileResponsiveFinancialsPage() {
       achievements.push({
         id: "needs-attention",
         title: "⚠️ Needs Attention",
-        description: `${lossProperties.length} customers need optimization`,
+        description: `${lossProperties.length} properties need optimization`,
         type: "warning",
         metric: lossProperties.length,
       })
@@ -2017,7 +2017,7 @@ export default function MobileResponsiveFinancialsPage() {
       achievements.push({
         id: "consistent-performer",
         title: "🎯 Consistent Performer",
-        description: `${consistentProperties.length} customers maintain steady 10-30% margins`,
+        description: `${consistentProperties.length} properties maintain steady 10-30% margins`,
         type: "info",
         metric: consistentProperties.length,
       })
@@ -2210,7 +2210,7 @@ export default function MobileResponsiveFinancialsPage() {
           <div className="flex justify-between items-center">
             <div>
               <h3 className="text-xl font-semibold text-gray-900">
-                Profit & Loss Statement {viewMode === "by-property" ? "(By Customer)" : "(Total)"}
+                Profit & Loss Statement {viewMode === "by-property" ? "(By Property)" : "(Total)"}
               </h3>
               <div className="mt-2 text-sm text-gray-600">
                 Showing {timePeriod.toLowerCase()} {viewMode} view for {selectedMonth}
@@ -2420,11 +2420,11 @@ export default function MobileResponsiveFinancialsPage() {
                 <div className="text-xs text-gray-500">{kpis.netMargin.toFixed(1)}% margin</div>
               </div>
               <div className="text-center">
-                <div className="text-sm text-gray-600 mb-1">📊 Customers</div>
+                <div className="text-sm text-gray-600 mb-1">📊 Properties</div>
                 <div className="text-xl font-bold text-purple-600">
                   {timeSeriesData?.availableProperties?.length || 0}
                 </div>
-                <div className="text-xs text-gray-500">Active customers</div>
+                <div className="text-xs text-gray-500">Active properties</div>
               </div>
             </div>
           </div>
@@ -2438,9 +2438,9 @@ export default function MobileResponsiveFinancialsPage() {
     return renderDesktopPLTable()
   }
 
-  // Add the missing renderSideBySideCustomerCards function
-  const renderSideBySideCustomerCards = () => {
-    return renderMobileCustomerCards()
+  // Add the missing renderSideBySidePropertyCards function
+  const renderSideBySidePropertyCards = () => {
+    return renderMobilePropertyCards()
   }
 
   const renderCompanyScorecard = () => {
@@ -2492,10 +2492,10 @@ export default function MobileResponsiveFinancialsPage() {
             </div>
           </div>
 
-          {/* Customer count */}
+          {/* Property count */}
           <div className="mt-4 pt-4 border-t border-white border-opacity-20">
             <div className="flex justify-between items-center text-sm">
-              <span className="opacity-75">Customers:</span>
+              <span className="opacity-75">Properties:</span>
               <span className="font-semibold">{timeSeriesData?.availableProperties?.length || 0}</span>
             </div>
             <div className="flex justify-between items-center text-sm mt-1">
@@ -2513,12 +2513,12 @@ export default function MobileResponsiveFinancialsPage() {
   // Mobile charts view
   const renderMobileCharts = () => (
     <div className="space-y-6">
-      {/* Customer Performance Chart */}
-      {generateCustomerChartData().length > 0 && (
+      {/* Property Performance Chart */}
+      {generatePropertyChartData().length > 0 && (
         <div className="bg-white rounded-lg shadow-sm overflow-hidden">
           <div className="p-4 border-b border-gray-200">
             <div className="flex justify-between items-center">
-              <h3 className="text-lg font-semibold text-gray-900">Customer Performance</h3>
+              <h3 className="text-lg font-semibold text-gray-900">Property Performance</h3>
               <div className="flex items-center gap-2">
                 <div className="flex rounded-lg border border-gray-300 overflow-hidden">
                   <button
@@ -2569,7 +2569,7 @@ export default function MobileResponsiveFinancialsPage() {
               {propertyChartView === "pie" ? (
                 <RechartsPieChart>
                   <Pie
-                    data={generateCustomerChartData()}
+                    data={generatePropertyChartData()}
                     cx="50%"
                     cy="50%"
                     outerRadius={80}
@@ -2579,7 +2579,7 @@ export default function MobileResponsiveFinancialsPage() {
                     label={({ name, percent }) => (percent > 0.1 ? `${(percent * 100).toFixed(0)}%` : "")}
                     labelLine={false}
                   >
-                    {generateCustomerChartData().map((entry, index) => (
+                    {generatePropertyChartData().map((entry, index) => (
                       <Cell
                         key={`cell-${index}`}
                         fill={COLORS[index % COLORS.length]}
@@ -2645,7 +2645,7 @@ export default function MobileResponsiveFinancialsPage() {
                   />
                 </RechartsPieChart>
               ) : (
-                <BarChart data={generateCustomerChartData()}>
+                <BarChart data={generatePropertyChartData()}>
                   <CartesianGrid strokeDasharray="2 2" stroke="#f1f5f9" />
                   <XAxis dataKey="name" hide />
                   <YAxis tickFormatter={(value) => `${(value / 1000).toFixed(0)}k`} tick={{ fontSize: 10 }} />
@@ -2688,20 +2688,20 @@ export default function MobileResponsiveFinancialsPage() {
     </div>
   )
 
-  const renderMobileCustomerCards = () => {
+  const renderMobilePropertyCards = () => {
     if (!timeSeriesData?.availableProperties || timeSeriesData.availableProperties.length === 0) {
       return (
         <div className="text-center py-8 text-gray-500">
           <div className="text-center">
             <PieChart className="w-12 h-12 mx-auto mb-3 text-gray-400" />
-            <p className="text-lg font-medium text-gray-600">No customer data available</p>
-            <p className="text-sm mt-2 text-gray-500">Switch to "By Customer" view to see customer breakdown</p>
+            <p className="text-lg font-medium text-gray-600">No property data available</p>
+            <p className="text-sm mt-2 text-gray-500">Switch to "By Property" view to see property breakdown</p>
           </div>
         </div>
       )
     }
 
-    // Get customer data and sort by profit (best performers first)
+    // Get property data and sort by profit (best performers first)
     const propertyData = timeSeriesData.availableProperties
       .map((property) => {
         const revenue = currentData
@@ -2748,16 +2748,16 @@ export default function MobileResponsiveFinancialsPage() {
         <div className="p-4 border-b border-gray-200">
           <div className="flex justify-between items-center">
             <div>
-              <h3 className="text-lg font-semibold text-gray-900">Customer Performance</h3>
+              <h3 className="text-lg font-semibold text-gray-900">Property Performance</h3>
               <div className="text-sm text-gray-600 mt-1">
-                {timePeriod} period • {propertyData.length} customers • Sorted by profit
+                {timePeriod} period • {propertyData.length} properties • Sorted by profit
               </div>
             </div>
             <div className="text-xs bg-purple-100 text-purple-800 px-2 py-1 rounded-full">🏢 Tap to view P&L</div>
           </div>
         </div>
 
-        {/* Horizontal scrolling customer cards */}
+        {/* Horizontal scrolling property cards */}
         <div className="p-4">
           <div className="flex gap-4 overflow-x-auto pb-2" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
             {propertyData.map((property, index) => (
@@ -2765,15 +2765,15 @@ export default function MobileResponsiveFinancialsPage() {
                 key={property.name}
                 className="flex-shrink-0 w-36 bg-gradient-to-br from-white to-gray-50 rounded-lg border border-gray-200 p-4 shadow-sm hover:shadow-md transition-all cursor-pointer"
                 onClick={() => {
-                  setSelectedCustomerForPL(property)
-                  setShowCustomerPL(true)
+                  setSelectedPropertyForPL(property)
+                  setShowPropertyPL(true)
                 }}
                 style={{
                   minWidth: "144px",
                   boxShadow: index === 0 ? `0 4px 6px -1px ${BRAND_COLORS.primary}33` : undefined,
                 }}
               >
-                {/* Customer name */}
+                {/* Property name */}
                 <div className="text-sm font-semibold text-gray-900 mb-3 truncate" title={property.name}>
                   {property.name}
                   {index === 0 && <span className="ml-1 text-xs">🏆</span>}
@@ -2814,27 +2814,27 @@ export default function MobileResponsiveFinancialsPage() {
 
         {/* Scroll indicator */}
         <div className="px-4 pb-4">
-          <div className="text-xs text-gray-500 text-center">👈 Scroll horizontally to see all customers</div>
+          <div className="text-xs text-gray-500 text-center">👈 Scroll horizontally to see all properties</div>
         </div>
       </div>
     )
   }
 
-  // Customer P&L modal/screen
-  const renderCustomerPLModal = () => {
-    if (!showCustomerPL || !selectedCustomerForPL) return null
+  // Property P&L modal/screen
+  const renderPropertyPLModal = () => {
+    if (!showPropertyPL || !selectedPropertyForPL) return null
 
-    const customer = selectedCustomerForPL
+    const property = selectedPropertyForPL
 
-    // Get detailed P&L data for this customer
-    const customerPLData = currentData
+    // Get detailed P&L data for this property
+    const propertyPLData = currentData
       .filter(
-        (account) => account.propertyTotals?.[customer.name] && account.propertyTotals[customer.name] !== 0,
+        (account) => account.propertyTotals?.[property.name] && account.propertyTotals[property.name] !== 0,
       )
       .map((account) => ({
         ...account,
-        total: account.propertyTotals[customer.name],
-        entries: account.propertyEntries?.[customer.name] || [],
+        total: account.propertyTotals[property.name],
+        entries: account.propertyEntries?.[property.name] || [],
       }))
       .sort((a, b) => {
         const categoryOrder = { Revenue: 0, COGS: 1, "Operating Expenses": 2, "Other Income": 3, "Other Expenses": 4 }
@@ -2850,11 +2850,11 @@ export default function MobileResponsiveFinancialsPage() {
           <div className="sticky top-0 bg-white border-b border-gray-200 p-4 z-10">
             <div className="flex justify-between items-center">
               <div>
-                <h2 className="text-xl font-bold text-gray-900">{customer.name}</h2>
+                <h2 className="text-xl font-bold text-gray-900">{property.name}</h2>
                 <div className="text-sm text-gray-600">{timePeriod} P&L Statement</div>
               </div>
               <button
-                onClick={() => setShowCustomerPL(false)}
+                onClick={() => setShowPropertyPL(false)}
                 className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
               >
                 <X className="w-6 h-6" />
@@ -2865,16 +2865,16 @@ export default function MobileResponsiveFinancialsPage() {
             <div className="mt-4 grid grid-cols-3 gap-4">
               <div className="text-center">
                 <div className="text-sm text-gray-500">Revenue</div>
-                <div className="text-lg font-bold text-green-600">{formatCurrency(customer.revenue)}</div>
+                <div className="text-lg font-bold text-green-600">{formatCurrency(property.revenue)}</div>
               </div>
               <div className="text-center">
                 <div className="text-sm text-gray-500">Expenses</div>
-                <div className="text-lg font-bold text-red-600">{formatCurrency(customer.expenses)}</div>
+                <div className="text-lg font-bold text-red-600">{formatCurrency(property.expenses)}</div>
               </div>
               <div className="text-center">
                 <div className="text-sm text-gray-500">Profit</div>
-                <div className={`text-lg font-bold ${customer.profit >= 0 ? "text-blue-600" : "text-red-600"}`}>
-                  {formatCurrency(customer.profit)}
+                <div className={`text-lg font-bold ${property.profit >= 0 ? "text-blue-600" : "text-red-600"}`}>
+                  {formatCurrency(property.profit)}
                 </div>
               </div>
             </div>
@@ -2883,7 +2883,7 @@ export default function MobileResponsiveFinancialsPage() {
           {/* P&L Details */}
           <div className="p-4 space-y-4">
             {categories.map((category) => {
-              const categoryAccounts = customerPLData.filter((account) => account.category === category)
+              const categoryAccounts = propertyPLData.filter((account) => account.category === category)
               if (categoryAccounts.length === 0) return null
 
               const categoryTotal = categoryAccounts.reduce((sum, account) => sum + account.total, 0)
@@ -3018,7 +3018,7 @@ export default function MobileResponsiveFinancialsPage() {
 
                       <div className="flex justify-between text-sm text-gray-600">
                         <span>ID: {entry.id}</span>
-                        <span>Customer: {entry.customer || "No Customer"}</span>
+                        <span>Property: {entry.customer || "No Property"}</span>
                       </div>
                     </div>
                   ))}
@@ -3121,7 +3121,7 @@ export default function MobileResponsiveFinancialsPage() {
                       {entry.memo && <div className="mb-2 text-xs text-gray-700">{entry.memo}</div>}
 
                       <div className="text-xs text-gray-600">
-                        <strong>Customer:</strong> {entry.customer || "No Customer"}
+                        <strong>Property:</strong> {entry.customer || "No Property"}
                       </div>
                     </div>
                   ))}
@@ -3201,14 +3201,14 @@ export default function MobileResponsiveFinancialsPage() {
                 ))}
               </select>
 
-              {/* Customer Dropdown */}
+              {/* Property Dropdown */}
               <div className="relative">
                 <button
                   onClick={() => setPropertyDropdownOpen(!propertyDropdownOpen)}
                   className="flex items-center justify-between w-56 px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm hover:border-blue-500 focus:outline-none focus:ring-2 transition-all"
                   style={{ "--tw-ring-color": BRAND_COLORS.secondary + "33" } as React.CSSProperties}
                 >
-                  <span className="truncate">{getSelectedCustomersText()}</span>
+                  <span className="truncate">{getSelectedPropertiesText()}</span>
                   <ChevronDown
                     className={`w-4 h-4 ml-2 transition-transform ${propertyDropdownOpen ? "rotate-180" : ""}`}
                   />
@@ -3217,7 +3217,7 @@ export default function MobileResponsiveFinancialsPage() {
                 {propertyDropdownOpen && (
                   <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-300 rounded-lg shadow-lg z-50 max-h-80 overflow-y-auto">
                     <div className="p-2 text-xs text-gray-500 border-b border-gray-100">
-                      Select customers to analyze
+                      Select properties to analyze
                     </div>
                     {availableProperties.map((property) => (
                       <div
@@ -3279,9 +3279,9 @@ export default function MobileResponsiveFinancialsPage() {
                     viewMode === "by-property" ? "text-white" : "bg-white text-gray-700 hover:bg-gray-50"
                   }`}
                   style={{ backgroundColor: viewMode === "by-property" ? BRAND_COLORS.primary : undefined }}
-                  title="View P&L with customers as columns"
+                  title="View P&L with properties as columns"
                 >
-                  By Customer
+                  By Property
                 </button>
               </div>
 
@@ -3366,11 +3366,11 @@ export default function MobileResponsiveFinancialsPage() {
 
         {/* Main Content Grid */}
         {deviceType === "mobile" ? (
-          // Mobile: Customer cards with drill-down
+// Mobile: Property cards with drill-down
           <div className="space-y-6">
             {renderCompanyScorecard()}
             {renderAchievementBadges()}
-            {renderSideBySideCustomerCards()}
+            {renderSideBySidePropertyCards()}
           </div>
         ) : (
           // Tablet/Desktop: Charts on top, P&L below
@@ -3396,8 +3396,8 @@ export default function MobileResponsiveFinancialsPage() {
       {/* Company P&L Modal - Mobile Only */}
       {deviceType === "mobile" && renderCompanyPLModal()}
 
-      {/* Mobile Customer P&L Modal */}
-      {renderCustomerPLModal()}
+      {/* Mobile Property P&L Modal */}
+      {renderPropertyPLModal()}
 
       {/* Mobile Transaction Detail Modal */}
       {renderTransactionDetailModal()}

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -95,7 +95,7 @@ interface JournalEntryLine {
 }
 
 type TimePeriod = "Monthly" | "Quarterly" | "YTD" | "Trailing 12" | "Custom";
-type ViewMode = "Total" | "Detail" | "Customer";
+type ViewMode = "Total" | "Detail" | "Property";
 type NotificationState = {
   show: boolean;
   message: string;
@@ -221,7 +221,7 @@ export default function FinancialsPage() {
   const [monthDropdownOpen, setMonthDropdownOpen] = useState(false);
   const [yearDropdownOpen, setYearDropdownOpen] = useState(false);
   const [selectedProperties, setSelectedProperties] = useState<Set<string>>(
-    new Set(["All Customers"]),
+    new Set(["All Properties"]),
   );
   const [customStartDate, setCustomStartDate] = useState("");
   const [customEndDate, setCustomEndDate] = useState("");
@@ -232,7 +232,7 @@ export default function FinancialsPage() {
   const [plAccounts, setPlAccounts] = useState<PLAccount[]>([]);
   const [dataError, setDataError] = useState<string | null>(null);
   const [availableProperties, setAvailableProperties] = useState<string[]>([
-    "All Customers",
+    "All Properties",
   ]);
   const [showTransactionModal, setShowTransactionModal] = useState(false);
   const [transactionModalTitle, setTransactionModalTitle] = useState("");
@@ -493,7 +493,7 @@ export default function FinancialsPage() {
     try {
       const { startDate, endDate } = calculateDateRange();
       const selectedProperty =
-        Array.from(selectedProperties)[0] || "All Customers";
+        Array.from(selectedProperties)[0] || "All Properties";
 
       smartLog(`🔍 TIMEZONE-INDEPENDENT P&L DATA FETCH`);
       smartLog(`📅 Period: ${startDate} to ${endDate}`);
@@ -528,7 +528,7 @@ export default function FinancialsPage() {
         .order("date", { ascending: true });
 
       // Apply property filter
-      if (selectedProperty !== "All Customers") {
+      if (selectedProperty !== "All Properties") {
         query = query.eq("customer", selectedProperty);
       }
 
@@ -578,7 +578,7 @@ export default function FinancialsPage() {
         }
       });
       setAvailableProperties([
-        "All Customers",
+        "All Properties",
         ...Array.from(properties).sort(),
       ]);
 
@@ -1226,8 +1226,8 @@ export default function FinancialsPage() {
   const getColumnHeaders = () => {
     if (viewMode === "Total") {
       return [];
-    } else if (viewMode === "Customer") {
-      return availableProperties.filter((p) => p !== "All Customers");
+    } else if (viewMode === "Property") {
+      return availableProperties.filter((p) => p !== "All Properties");
     } else if (viewMode === "Detail") {
       // For Detail view, show months in the date range using timezone-independent method
       const { startDate, endDate } = calculateDateRange();
@@ -1276,7 +1276,7 @@ export default function FinancialsPage() {
       ];
     }
 
-    if (viewMode === "Customer") {
+    if (viewMode === "Property") {
       // Filter transactions by property and calculate total
       const filteredTransactions = transactions.filter(
         (tx) => tx.customer === header,
@@ -1372,8 +1372,8 @@ export default function FinancialsPage() {
       });
     }
 
-    // Filter by property if specified (Customer view)
-    if (property && viewMode === "Customer") {
+    // Filter by property if specified (Property view)
+    if (property && viewMode === "Property") {
       transactions = transactions.filter((tx) => tx.customer === property);
     }
 
@@ -1678,7 +1678,7 @@ export default function FinancialsPage() {
                   } as React.CSSProperties
                 }
               >
-                Customers: {Array.from(selectedProperties).join(", ")}
+                Properties: {Array.from(selectedProperties).join(", ")}
                 <ChevronDown className="w-4 h-4 ml-2" />
               </button>
 
@@ -1695,17 +1695,17 @@ export default function FinancialsPage() {
                         onChange={(e) => {
                           const newSelected = new Set(selectedProperties);
                           if (e.target.checked) {
-                            if (property === "All Customers") {
+                            if (property === "All Properties") {
                               newSelected.clear();
-                              newSelected.add("All Customers");
+                              newSelected.add("All Properties");
                             } else {
-                              newSelected.delete("All Customers");
+                              newSelected.delete("All Properties");
                               newSelected.add(property);
                             }
                           } else {
                             newSelected.delete(property);
                             if (newSelected.size === 0) {
-                              newSelected.add("All Customers");
+                              newSelected.add("All Properties");
                             }
                           }
                           setSelectedProperties(newSelected);
@@ -1750,20 +1750,20 @@ export default function FinancialsPage() {
               >
                 Detail
               </button>
-<button
-  onClick={() => setViewMode("Customer")}
-  className={`px-4 py-2 text-sm font-medium rounded-r-lg border-l border-gray-300 ${
-    viewMode === "Customer"
-      ? "text-white"
-      : "text-gray-700 hover:bg-gray-50"
-  }`}
-  style={{
-    backgroundColor:
-      viewMode === "Customer" ? BRAND_COLORS.primary : undefined,  // ← Changed from "Customer" to "Customer"
-  }}
->
-  Customer  {/* ← Changed from "Customer" to "Customer" */}
-</button>
+              <button
+                onClick={() => setViewMode("Property")}
+                className={`px-4 py-2 text-sm font-medium rounded-r-lg border-l border-gray-300 ${
+                  viewMode === "Property"
+                    ? "text-white"
+                    : "text-gray-700 hover:bg-gray-50"
+                }`}
+                style={{
+                  backgroundColor:
+                    viewMode === "Property" ? BRAND_COLORS.primary : undefined,
+                }}
+              >
+                Property
+              </button>
             </div>
 
             {/* Custom Date Range */}
@@ -1944,7 +1944,7 @@ export default function FinancialsPage() {
                   {plAccounts.length} accounts • Timezone-independent date
                   handling • Using account_type for P&L classification
                   {viewMode === "Detail" && " • Monthly breakdown"}
-                  {viewMode === "Customer" && " • By property"}
+                  {viewMode === "Property" && " • By property"}
                 </p>
               </div>
 
@@ -2056,7 +2056,7 @@ export default function FinancialsPage() {
                                       viewMode === "Detail"
                                         ? header
                                         : undefined,
-                                      viewMode === "Customer" ? header : undefined,
+                                      viewMode === "Property" ? header : undefined,
                                       !expandedAccounts.has(
                                         group.account.account,
                                       ), // Show combined if collapsed
@@ -2132,7 +2132,7 @@ export default function FinancialsPage() {
                                           viewMode === "Detail"
                                             ? header
                                             : undefined,
-                                          viewMode === "Customer"
+                                          viewMode === "Property"
                                             ? header
                                             : undefined,
                                         )
@@ -2272,7 +2272,7 @@ export default function FinancialsPage() {
                                       viewMode === "Detail"
                                         ? header
                                         : undefined,
-                                      viewMode === "Customer" ? header : undefined,
+                                      viewMode === "Property" ? header : undefined,
                                       !expandedAccounts.has(
                                         group.account.account,
                                       ), // Show combined if collapsed
@@ -2348,7 +2348,7 @@ export default function FinancialsPage() {
                                           viewMode === "Detail"
                                             ? header
                                             : undefined,
-                                          viewMode === "Customer"
+                                          viewMode === "Property"
                                             ? header
                                             : undefined,
                                         )
@@ -2604,7 +2604,7 @@ export default function FinancialsPage() {
                                       viewMode === "Detail"
                                         ? header
                                         : undefined,
-                                      viewMode === "Customer" ? header : undefined,
+                                      viewMode === "Property" ? header : undefined,
                                       !expandedAccounts.has(
                                         group.account.account,
                                       ), // Show combined if collapsed
@@ -2680,7 +2680,7 @@ export default function FinancialsPage() {
                                           viewMode === "Detail"
                                             ? header
                                             : undefined,
-                                          viewMode === "Customer"
+                                          viewMode === "Property"
                                             ? header
                                             : undefined,
                                         )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -150,11 +150,11 @@ export default function FinancialOverviewPage() {
   const [timePeriodDropdownOpen, setTimePeriodDropdownOpen] = useState(false);
   const [monthDropdownOpen, setMonthDropdownOpen] = useState(false);
   const [yearDropdownOpen, setYearDropdownOpen] = useState(false);
-  const [customerDropdownOpen, setCustomerDropdownOpen] = useState(false);
+  const [propertyDropdownOpen, setPropertyDropdownOpen] = useState(false);
   const timePeriodDropdownRef = useRef<HTMLDivElement>(null);
   const monthDropdownRef = useRef<HTMLDivElement>(null);
   const yearDropdownRef = useRef<HTMLDivElement>(null);
-  const customerDropdownRef = useRef<HTMLDivElement>(null);
+  const propertyDropdownRef = useRef<HTMLDivElement>(null);
   const [financialData, setFinancialData] = useState(null);
   const [error, setError] = useState(null);
   const [lastUpdated, setLastUpdated] = useState(null);
@@ -185,18 +185,18 @@ export default function FinancialOverviewPage() {
   const [propertyChartMetric, setPropertyChartMetric] = useState<
     "income" | "gp" | "ni" | "expenses" | "cogs"
   >("income");
-  const [customerChartType, setCustomerChartType] = useState<"pie" | "bar">(
+  const [propertyChartType, setPropertyChartType] = useState<"pie" | "bar">(
     "pie",
   );
   const [loadingTrend, setLoadingTrend] = useState(false);
   const [loadingProperty, setLoadingProperty] = useState(false);
   const [trendError, setTrendError] = useState<string | null>(null);
   const [propertyError, setPropertyError] = useState<string | null>(null);
-  const [selectedCustomers, setSelectedCustomers] = useState<Set<string>>(
-    new Set(["All Customers"]),
+  const [selectedProperties, setSelectedProperties] = useState<Set<string>>(
+    new Set(["All Properties"]),
   );
-  const [availableCustomers, setAvailableCustomers] = useState<string[]>([
-    "All Customers",
+  const [availableProperties, setAvailableProperties] = useState<string[]>([
+    "All Properties",
   ]);
   const [customStartDate, setCustomStartDate] = useState("");
   const [customEndDate, setCustomEndDate] = useState("");
@@ -354,10 +354,10 @@ export default function FinancialOverviewPage() {
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
-        customerDropdownRef.current &&
-        !customerDropdownRef.current.contains(event.target as Node)
+        propertyDropdownRef.current &&
+        !propertyDropdownRef.current.contains(event.target as Node)
       ) {
-        setCustomerDropdownOpen(false);
+        setPropertyDropdownOpen(false);
       }
       if (
         timePeriodDropdownRef.current &&
@@ -385,8 +385,8 @@ export default function FinancialOverviewPage() {
     };
   }, []);
 
-  // Load available customers for filter dropdown
-  const fetchAvailableCustomers = async () => {
+  // Load available properties for filter dropdown
+  const fetchAvailableProperties = async () => {
     try {
       const { data, error } = await supabase
         .from("journal_entry_lines")
@@ -399,14 +399,14 @@ export default function FinancialOverviewPage() {
           customers.add(row.customer.trim());
         }
       });
-      setAvailableCustomers(["All Customers", ...Array.from(customers).sort()]);
+      setAvailableProperties(["All Properties", ...Array.from(customers).sort()]);
     } catch (err) {
-      console.error("Error fetching customers:", err);
+      console.error("Error fetching properties:", err);
     }
   };
 
   useEffect(() => {
-    fetchAvailableCustomers();
+    fetchAvailableProperties();
   }, []);
 
   // Fetch financial data from Supabase (same connection as other pages)
@@ -418,8 +418,8 @@ export default function FinancialOverviewPage() {
       const { startDate, endDate } = calculateDateRange();
       const monthIndex = monthsList.indexOf(selectedMonth);
       const year = Number.parseInt(selectedYear);
-      const selectedCustomerList = Array.from(selectedCustomers).filter(
-        (c) => c !== "All Customers",
+      const selectedPropertyList = Array.from(selectedProperties).filter(
+        (c) => c !== "All Properties",
       );
 
       console.log(
@@ -427,10 +427,10 @@ export default function FinancialOverviewPage() {
       );
       console.log(`📅 Date range: ${startDate} to ${endDate}`);
       console.log(
-        `🏢 Customer Filter: ${
-          selectedCustomerList.length > 0
-            ? selectedCustomerList.join(", ")
-            : "All Customers"
+        `🏢 Property Filter: ${
+          selectedPropertyList.length > 0
+            ? selectedPropertyList.join(", ")
+            : "All Properties"
         }`,
       );
 
@@ -462,8 +462,8 @@ export default function FinancialOverviewPage() {
         .lte("date", endDate)
         .order("date", { ascending: true });
 
-      if (selectedCustomerList.length > 0) {
-        currentQuery = currentQuery.in("customer", selectedCustomerList);
+      if (selectedPropertyList.length > 0) {
+        currentQuery = currentQuery.in("customer", selectedPropertyList);
       }
 
       const { data: currentTransactions, error: currentError } =
@@ -521,8 +521,8 @@ export default function FinancialOverviewPage() {
         .lte("date", prevEndDate)
         .order("date", { ascending: true });
 
-      if (selectedCustomerList.length > 0) {
-        prevQuery = prevQuery.in("customer", selectedCustomerList);
+      if (selectedPropertyList.length > 0) {
+        prevQuery = prevQuery.in("customer", selectedPropertyList);
       }
 
       const { data: prevTransactions, error: prevError } = await prevQuery;
@@ -585,8 +585,8 @@ export default function FinancialOverviewPage() {
           .lte("date", trendEndDate)
           .order("date", { ascending: true });
 
-        if (selectedCustomerList.length > 0) {
-          monthQuery = monthQuery.in("customer", selectedCustomerList);
+        if (selectedPropertyList.length > 0) {
+          monthQuery = monthQuery.in("customer", selectedPropertyList);
         }
 
         const { data: monthData } = await monthQuery;
@@ -901,15 +901,15 @@ export default function FinancialOverviewPage() {
       });
     }
 
-    // Profitable customers
-    const profitableCustomers = properties.filter((p) => p.netIncome > 0);
-    if (profitableCustomers.length > 0) {
+    // Profitable properties
+    const profitableProperties = properties.filter((p) => p.netIncome > 0);
+    if (profitableProperties.length > 0) {
       alerts.push({
-        id: "profitable-customers",
+        id: "profitable-properties",
         type: "success",
-        title: "Strong Customer Performance",
-        message: `${profitableCustomers.length} of ${properties.length} customers are profitable`,
-        action: "View Customers",
+        title: "Strong Property Performance",
+        message: `${profitableProperties.length} of ${properties.length} properties are profitable`,
+        action: "View Properties",
         href: "/financials",
       });
     }
@@ -949,15 +949,15 @@ export default function FinancialOverviewPage() {
       setLoadingTrend(true);
       setTrendError(null);
       const endMonth = monthsList.indexOf(selectedMonth) + 1;
-      const selectedCustomerList = Array.from(selectedCustomers).filter(
-        (c) => c !== "All Customers",
+      const selectedPropertyList = Array.from(selectedProperties).filter(
+        (c) => c !== "All Properties",
       );
-      const customerQuery =
-        selectedCustomerList.length > 0
-          ? `&customerId=${encodeURIComponent(selectedCustomerList.join(","))}`
+      const propertyQuery =
+        selectedPropertyList.length > 0
+          ? `&customerId=${encodeURIComponent(selectedPropertyList.join(","))}`
           : "";
       const res = await fetch(
-        `/api/organizations/${orgId}/trend-data?months=12&endMonth=${endMonth}&endYear=${selectedYear}${customerQuery}`,
+        `/api/organizations/${orgId}/trend-data?months=12&endMonth=${endMonth}&endYear=${selectedYear}${propertyQuery}`,
       );
       if (!res.ok) throw new Error("Failed to fetch trend data");
       const json: { monthlyData: MonthlyPoint[] } = await res.json();
@@ -1018,7 +1018,7 @@ export default function FinancialOverviewPage() {
     timePeriod,
     selectedMonth,
     selectedYear,
-    selectedCustomers,
+    selectedProperties,
     customStartDate,
     customEndDate,
   ]);
@@ -1100,12 +1100,12 @@ export default function FinancialOverviewPage() {
     margin: "margin",
     transactionCount: "transactions",
   } as const;
-  const customerSubtitle =
+  const propertySubtitle =
     timePeriod === "Monthly"
-      ? `Top 10 customers sorted by ${sortLabels[sortColumn]} for ${selectedMonth} ${selectedYear}`
-      : `Top 10 customers sorted by ${sortLabels[sortColumn]} for ${formatDate(propertyStart)} - ${formatDate(propertyEnd)}`;
+      ? `Top 10 properties sorted by ${sortLabels[sortColumn]} for ${selectedMonth} ${selectedYear}`
+      : `Top 10 properties sorted by ${sortLabels[sortColumn]} for ${formatDate(propertyStart)} - ${formatDate(propertyEnd)}`;
 
-  const sortedCustomers = useMemo(() => {
+  const sortedProperties = useMemo(() => {
     if (!financialData?.propertyBreakdown) return [];
     return [...financialData.propertyBreakdown]
       .map((p) => ({
@@ -1122,8 +1122,8 @@ export default function FinancialOverviewPage() {
       .slice(0, 10);
   }, [financialData, sortColumn, sortDirection]);
 
-  const topCustomerTotals = useMemo(() => {
-    const totals = sortedCustomers.reduce(
+  const topPropertyTotals = useMemo(() => {
+    const totals = sortedProperties.reduce(
       (acc, p) => {
         acc.revenue += p.revenue || 0;
         acc.expenses += p.expenses || 0;
@@ -1136,7 +1136,7 @@ export default function FinancialOverviewPage() {
       ...totals,
       margin: totals.revenue ? (totals.netIncome / totals.revenue) * 100 : 0,
     };
-  }, [sortedCustomers]);
+  }, [sortedProperties]);
 
   const handleSort = (column: SortColumn) => {
     if (sortColumn === column) {
@@ -1209,7 +1209,7 @@ export default function FinancialOverviewPage() {
     },
     {
       title: "Accounts Receivable",
-      description: "Customer payments and aging",
+      description: "Property payments and aging",
       href: "/accounts-receivable",
       icon: CreditCard,
       color: BRAND_COLORS.warning,
@@ -1584,9 +1584,9 @@ export default function FinancialOverviewPage() {
                     </CardTitle>
                   </div>
                   <div className="flex items-center gap-2">
-                    <div className="relative" ref={customerDropdownRef}>
+                    <div className="relative" ref={propertyDropdownRef}>
                       <button
-                        onClick={() => setCustomerDropdownOpen(!customerDropdownOpen)}
+                        onClick={() => setPropertyDropdownOpen(!propertyDropdownOpen)}
                         className="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
                         style={
                           {
@@ -1594,37 +1594,37 @@ export default function FinancialOverviewPage() {
                           } as React.CSSProperties
                         }
                       >
-                        Customer: {Array.from(selectedCustomers).join(", ")}
+                        Property: {Array.from(selectedProperties).join(", ")}
                         <ChevronDown className="w-4 h-4 ml-1" />
                       </button>
 
-                      {customerDropdownOpen && (
+                      {propertyDropdownOpen && (
                         <div className="absolute right-0 z-10 mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto">
-                          {availableCustomers.map((cust) => (
+                          {availableProperties.map((cust) => (
                             <label
                               key={cust}
                               className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 cursor-pointer"
                             >
                               <input
                                 type="checkbox"
-                                checked={selectedCustomers.has(cust)}
+                                checked={selectedProperties.has(cust)}
                                 onChange={(e) => {
-                                  const newSelected = new Set(selectedCustomers);
+                                  const newSelected = new Set(selectedProperties);
                                   if (e.target.checked) {
-                                    if (cust === "All Customers") {
+                                    if (cust === "All Properties") {
                                       newSelected.clear();
-                                      newSelected.add("All Customers");
+                                      newSelected.add("All Properties");
                                     } else {
-                                      newSelected.delete("All Customers");
+                                      newSelected.delete("All Properties");
                                       newSelected.add(cust);
                                     }
                                   } else {
                                     newSelected.delete(cust);
                                     if (newSelected.size === 0) {
-                                      newSelected.add("All Customers");
+                                      newSelected.add("All Properties");
                                     }
                                   }
-                                  setSelectedCustomers(newSelected);
+                                  setSelectedProperties(newSelected);
                                 }}
                                 className="mr-3 rounded"
                                 style={{ accentColor: BRAND_COLORS.primary }}
@@ -1737,13 +1737,13 @@ export default function FinancialOverviewPage() {
                 </CardContent>
               </Card>
 
-              {/* Customer Performance Pie Chart */}
+              {/* Property Performance Pie Chart */}
               <Card>
                 <CardHeader className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <PieChart className="h-4 w-4 text-gray-600" />
                     <CardTitle className="text-lg font-semibold">
-                      Customer Performance
+                      Property Performance
                     </CardTitle>
                   </div>
                   <div className="flex items-center gap-2">
@@ -1765,21 +1765,21 @@ export default function FinancialOverviewPage() {
                     <div className="flex gap-1">
                       <Button
                         className={`h-8 w-8 p-0 ${
-                          customerChartType === "pie"
+                          propertyChartType === "pie"
                             ? ""
                             : "bg-white text-gray-700 border border-gray-200"
                         }`}
-                        onClick={() => setCustomerChartType("pie")}
+                        onClick={() => setPropertyChartType("pie")}
                       >
                         <PieChart className="h-4 w-4" />
                       </Button>
                       <Button
                         className={`h-8 w-8 p-0 ${
-                          customerChartType === "bar"
+                          propertyChartType === "bar"
                             ? ""
                             : "bg-white text-gray-700 border border-gray-200"
                         }`}
-                        onClick={() => setCustomerChartType("bar")}
+                        onClick={() => setPropertyChartType("bar")}
                       >
                         <BarChart3 className="h-4 w-4" />
                       </Button>
@@ -1794,7 +1794,7 @@ export default function FinancialOverviewPage() {
                   )}
                   {loadingProperty && (
                     <div className="text-sm text-gray-500">
-                      Loading customers...
+                      Loading properties...
                     </div>
                   )}
                   {!loadingProperty && propertyChartData.length === 0 && (
@@ -1810,7 +1810,7 @@ export default function FinancialOverviewPage() {
                   )}
                   {!loadingProperty && propertyChartData.length > 0 && (
                     <ResponsiveContainer width="100%" height={300}>
-                      {customerChartType === "pie" ? (
+                      {propertyChartType === "pie" ? (
                         <RechartsPieChart>
                           <Pie
                             data={propertyChartData}
@@ -1972,14 +1972,14 @@ export default function FinancialOverviewPage() {
               </div>
             </div>
 
-            {/* Top Customers Performance */}
+            {/* Top Properties Performance */}
             <div className="bg-white rounded-lg shadow-sm overflow-hidden">
               <div className="p-6 border-b border-gray-200">
                 <h3 className="text-lg font-semibold text-gray-900">
-                  Top Performing Customers
+                  Top Performing Properties
                 </h3>
                 <div className="text-sm text-gray-600 mt-1">
-                  {customerSubtitle}
+                  {propertySubtitle}
                 </div>
               </div>
               <div className="overflow-x-auto">
@@ -1987,7 +1987,7 @@ export default function FinancialOverviewPage() {
                   <thead className="bg-gray-50">
                     <tr>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Customer
+                        Property
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         <button
@@ -2082,10 +2082,10 @@ export default function FinancialOverviewPage() {
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
-                    {sortedCustomers.map((customer, index) => {
-                      const margin = customer.margin;
+                    {sortedProperties.map((property, index) => {
+                      const margin = property.margin;
                       return (
-                        <tr key={customer.name} className="hover:bg-gray-50">
+                        <tr key={property.name} className="hover:bg-gray-50">
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="flex items-center">
                               <div
@@ -2100,25 +2100,25 @@ export default function FinancialOverviewPage() {
                                 }`}
                               ></div>
                               <div className="text-sm font-medium text-gray-900">
-                                {customer.name}
+                                {property.name}
                               </div>
                             </div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            {formatCurrency(customer.revenue)}
+                            {formatCurrency(property.revenue)}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            {formatCurrency(customer.expenses)}
+                            {formatCurrency(property.expenses)}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <span
                               className={`text-sm font-medium ${
-                                customer.netIncome >= 0
+                                property.netIncome >= 0
                                   ? "text-green-600"
                                   : "text-red-600"
                               }`}
                             >
-                              {formatCurrency(customer.netIncome)}
+                              {formatCurrency(property.netIncome)}
                             </span>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
@@ -2145,30 +2145,30 @@ export default function FinancialOverviewPage() {
               </div>
             </div>
 
-            {/* Top Customers Summary */}
+            {/* Top Properties Summary */}
             <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-6 border border-blue-200">
               <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
                 <div className="text-center">
                   <div className="text-2xl font-bold text-blue-600">
-                    {formatCurrency(topCustomerTotals.revenue)}
+                    {formatCurrency(topPropertyTotals.revenue)}
                   </div>
                   <div className="text-sm text-gray-600 mt-1">Revenue</div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-purple-600">
-                    {formatCurrency(topCustomerTotals.expenses)}
+                    {formatCurrency(topPropertyTotals.expenses)}
                   </div>
                   <div className="text-sm text-gray-600 mt-1">Expenses</div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-green-600">
-                    {formatCurrency(topCustomerTotals.netIncome)}
+                    {formatCurrency(topPropertyTotals.netIncome)}
                   </div>
                   <div className="text-sm text-gray-600 mt-1">Net Income</div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-orange-600">
-                    {topCustomerTotals.margin.toFixed(1)}%
+                    {topPropertyTotals.margin.toFixed(1)}%
                   </div>
                   <div className="text-sm text-gray-600 mt-1">Margin</div>
                 </div>


### PR DESCRIPTION
## Summary
- rename customer-related labels to property on the financials page
- adjust P&L dashboard to filter and chart by property
- update financial overview tab to use property terminology

## Testing
- `pnpm lint` *(fails: Do not pass children as props, Unexpected any, and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a74a2e19108333a95de64737d784da