### PR TITLE
feat: center page headers

### DIFF
--- a/src/app/balance-sheet/page.tsx
+++ b/src/app/balance-sheet/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react"
 import { RefreshCw, X } from "lucide-react"
 import { supabase } from "@/lib/supabaseClient"
+import { PageHeader } from "@/components/PageHeader"
 
 // I AM CFO Brand Colors
 const BRAND_COLORS = {
@@ -1028,38 +1029,35 @@ export default function BalanceSheetPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-4 sm:py-6">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div>
-              <h1 className="text-xl sm:text-2xl font-bold text-gray-900">Balance Sheet</h1>
-              <p className="text-xs sm:text-sm text-gray-600 mt-1">
-                As of{" "}
-                {asOfDate
-                  ? formatDate(asOfDate)
-                  : timePeriod === "Monthly"
-                    ? `${selectedMonth} ${selectedYear}`
-                    : timePeriod === "Quarterly"
-                      ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                      : `${timePeriod} Period`}
-              </p>
-              <p className="text-xs text-blue-600 mt-1">
-                💰 Enhanced with account type subtotals and corrected balance calculations
-              </p>
-            </div>
-
-            <button
-              onClick={loadData}
-              disabled={isLoading}
-              className="flex items-center gap-2 px-3 sm:px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
-            >
-              <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
-              <span className="hidden sm:inline">Refresh</span>
-            </button>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Balance Sheet"
+        subtitle={
+          <>
+            As of{" "}
+            {asOfDate
+              ? formatDate(asOfDate)
+              : timePeriod === "Monthly"
+                ? `${selectedMonth} ${selectedYear}`
+                : timePeriod === "Quarterly"
+                  ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
+                  : `${timePeriod} Period`}
+          </>
+        }
+        right={
+          <button
+            onClick={loadData}
+            disabled={isLoading}
+            className="flex items-center gap-2 px-3 sm:px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
+          >
+            <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
+            <span className="hidden sm:inline">Refresh</span>
+          </button>
+        }
+      >
+        <p className="text-xs text-blue-600 mt-1">
+          💰 Enhanced with account type subtotals and corrected balance calculations
+        </p>
+      </PageHeader>
 
       {/* Filters */}
       <div className="bg-white border-b">

--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -1444,8 +1444,8 @@ export default function CashFlowPage() {
       {/* Header */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="relative flex justify-center">
+            <div className="flex flex-col items-center text-center">
               <h1 className="text-2xl font-bold text-gray-900">Cash Flow Statement</h1>
               <p className="text-sm text-gray-600 mt-1">
                 {timePeriod === "Custom"
@@ -1469,7 +1469,7 @@ export default function CashFlowPage() {
               </p>
             </div>
 
-            <div className="flex items-center space-x-4">
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center space-x-4">
               {/* View Mode Toggle */}
               <div className="flex bg-gray-100 rounded-lg p-1">
                 <button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,6 +39,7 @@ import {
 } from "recharts";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { PageHeader } from "@/components/PageHeader";
 import { supabase } from "@/lib/supabaseClient";
 
 // I AM CFO Brand Colors
@@ -1239,45 +1240,38 @@ const processCashFlowTransactions = (transactions: any[]) => {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="relative flex justify-center">
-            <div className="flex flex-col items-center text-center">
-              <h1 className="text-2xl font-bold text-gray-900">
-                Financial Overview
-              </h1>
-              <p className="text-sm text-gray-600 mt-1">
-                {timePeriod === "Custom"
-                  ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
-                  : timePeriod === "Monthly"
-                    ? `${selectedMonth} ${selectedYear}`
-                    : timePeriod === "Quarterly"
-                      ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                      : timePeriod === "YTD"
-                        ? `January - ${selectedMonth} ${selectedYear}`
-                        : timePeriod === "Trailing 12"
-                          ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
-                          : `${timePeriod} Period`}
-              </p>
-              {lastUpdated && (
-                <p className="text-xs text-gray-500 mt-1">
-                  Last updated: {lastUpdated.toLocaleString()}
-                </p>
-              )}
-            </div>
-            <button
-              onClick={fetchFinancialData}
-              disabled={isLoading}
-              className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-2 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
-            >
-              <RefreshCw
-                className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`}
-              />
-              {isLoading ? "Loading..." : "Refresh"}
-            </button>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Financial Overview"
+        subtitle={
+          timePeriod === "Custom"
+            ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+            : timePeriod === "Monthly"
+              ? `${selectedMonth} ${selectedYear}`
+              : timePeriod === "Quarterly"
+                ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
+                : timePeriod === "YTD"
+                  ? `January - ${selectedMonth} ${selectedYear}`
+                  : timePeriod === "Trailing 12"
+                    ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                    : `${timePeriod} Period`
+        }
+        right={
+          <button
+            onClick={fetchFinancialData}
+            disabled={isLoading}
+            className="flex items-center gap-2 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
+          >
+            <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
+            {isLoading ? "Loading..." : "Refresh"}
+          </button>
+        }
+      >
+        {lastUpdated && (
+          <p className="text-xs text-gray-500 mt-1">
+            Last updated: {lastUpdated.toLocaleString()}
+          </p>
+        )}
+      </PageHeader>
 
       {/* Filters */}
       <div className="bg-white border-b">

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface PageHeaderProps {
+  title: string;
+  subtitle?: React.ReactNode;
+  children?: React.ReactNode;
+  right?: React.ReactNode;
+}
+
+export function PageHeader({ title, subtitle, children, right }: PageHeaderProps) {
+  return (
+    <div className="bg-white shadow-sm border-b border-gray-200">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div className="relative flex justify-center">
+          <div className="flex flex-col items-center text-center">
+            <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
+            {subtitle && <p className="text-sm text-gray-600 mt-1">{subtitle}</p>}
+            {children}
+          </div>
+          {right && (
+            <div className="absolute right-0 top-1/2 -translate-y-1/2">{right}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable PageHeader component
- center overview and balance sheet headers
- align cash flow header to match centered style

## Testing
- `pnpm lint` *(fails: React/TypeScript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b734d87b708333b0ec7e1301609d53