### PR TITLE
Center reservation management header on reservations page

### DIFF
--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -140,33 +140,6 @@ const calculateKPIsFromReservations = (reservations: Reservation[]): KPIs => {
   return { totalRevenue, avgNightlyRate, avgStayLength, occupancyRate: 82 };
 };
 
-// Components
-const IAMCFOLogo = ({ className = "w-8 h-8" }: { className?: string }) => (
-  <div className={`${className} flex items-center justify-center relative`}>
-    <svg viewBox="0 0 120 120" className="w-full h-full">
-      <circle cx="60" cy="60" r="55" fill="#E2E8F0" stroke="#CBD5E1" strokeWidth="2"/>
-      <circle cx="60" cy="60" r="42" fill={BRAND_COLORS.primary}/>
-      <g fill="white">
-        <rect x="35" y="70" width="6" height="15" rx="1"/>
-        <rect x="44" y="65" width="6" height="20" rx="1"/>
-        <rect x="53" y="55" width="6" height="30" rx="1"/>
-        <rect x="62" y="50" width="6" height="35" rx="1"/>
-        <rect x="71" y="60" width="6" height="25" rx="1"/>
-        <rect x="80" y="45" width="6" height="40" rx="1"/>
-        <path d="M35 72 L44 67 L53 57 L62 52 L71 62 L80 47" 
-              stroke="#FFFFFF" strokeWidth="2.5" fill="none"/>
-        <circle cx="35" cy="72" r="2.5" fill="#FFFFFF"/>
-        <circle cx="44" cy="67" r="2.5" fill="#FFFFFF"/>
-        <circle cx="53" cy="57" r="2.5" fill="#FFFFFF"/>
-        <circle cx="62" cy="52" r="2.5" fill="#FFFFFF"/>
-        <circle cx="71" cy="62" r="2.5" fill="#FFFFFF"/>
-        <circle cx="80" cy="47" r="2.5" fill="#FFFFFF"/>
-      </g>
-      <text x="60" y="95" textAnchor="middle" fill="white" fontSize="11" fontWeight="bold" fontFamily="Arial, sans-serif">CFO</text>
-    </svg>
-  </div>
-);
-
 const PropertyDropdown = ({
   properties,
   selectedProperties,
@@ -1069,25 +1042,18 @@ async function connectToAPI() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Page Header with I AM CFO Branding */}
+      {/* Page Header */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center">
-            <IAMCFOLogo className="w-8 h-8 mr-4" />
-            <div>
-              <div className="flex items-center space-x-3">
-                <h1 className="text-2xl font-bold text-gray-900">I AM CFO</h1>
-                <span className="text-sm px-3 py-1 rounded-full text-white" style={{ backgroundColor: BRAND_COLORS.primary }}>
-                  Reservation Management
-                </span>
-                {isConnectedToBackend && (
-                  <span className="text-xs px-2 py-1 rounded-full bg-green-100 text-green-800">
-                    Guesty Connected
-                  </span>
-                )}
-              </div>
-              <p className="text-sm text-gray-600 mt-1">Real-time booking analytics • Airbnb/Guesty Integration • Revenue Optimization</p>
-            </div>
+          <div className="flex justify-center items-center gap-3">
+            <h1 className="text-3xl font-bold text-center" style={{ color: BRAND_COLORS.primary }}>
+              Reservation Management
+            </h1>
+            {isConnectedToBackend && (
+              <span className="text-xs px-2 py-1 rounded-full bg-green-100 text-green-800">
+                Guesty Connected
+              </span>
+            )}
           </div>
         </div>
       </div>
@@ -1096,7 +1062,6 @@ async function connectToAPI() {
         <div className="space-y-8">
           {/* Controls */}
           <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-4">
-            <h2 className="text-3xl font-bold" style={{ color: BRAND_COLORS.primary }}>Reservation Management</h2>
             <div className="flex flex-wrap gap-4 items-center">
               <div className="relative" ref={monthDropdownRef}>
                 <button


### PR DESCRIPTION
## Summary
- Simplify reservations header to show centered "Reservation Management" title
- Remove I AM CFO branding and redundant heading from reservations page

## Testing
- `npm run lint` *(fails: Do not pass children as props, Unexpected any, and other existing issues)*
- `npm run type-check` *(fails: implicit any types and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b743aa26848333b3ece8e79a38e92e