### PR TITLE
Add voice AI CFO example with server and mobile code

### DIFF
--- a/examples/voice-cfo/README.md
+++ b/examples/voice-cfo/README.md
@@ -1,0 +1,34 @@
+# Voice AI CFO Example
+
+This example demonstrates how to build a mobile voice interface that
+handles reservation questions in a CFO-style voice.
+
+## Server
+
+`server/main.py` exposes a `/ask-cfo` endpoint using FastAPI. It:
+
+1. Accepts an uploaded audio file.
+2. Transcribes speech with `gpt-4o-mini-transcribe`.
+3. Generates a concise answer using `gpt-4o` with a CFO persona.
+4. Converts the text reply back into speech.
+5. Streams the result as an MP3.
+
+Start the server:
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+## Mobile
+
+`mobile/App.js` is a minimal React Native (Expo) client that records
+audio, POSTs it to the server, and plays back the CFO voice answer.
+Install dependencies:
+
+```bash
+expo install expo-av buffer
+```
+
+Run the app with Expo and update `YOUR_SERVER_IP` to point at the
+running server.

--- a/examples/voice-cfo/mobile/App.js
+++ b/examples/voice-cfo/mobile/App.js
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { Button, View } from "react-native";
+import { Audio } from "expo-av";
+import { Buffer } from "buffer";
+
+export default function App() {
+  const [recording, setRecording] = useState(null);
+
+  const startRecording = async () => {
+    await Audio.requestPermissionsAsync();
+    const rec = new Audio.Recording();
+    await rec.prepareToRecordAsync(Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY);
+    await rec.startAsync();
+    setRecording(rec);
+  };
+
+  const stopAndSend = async () => {
+    await recording.stopAndUnloadAsync();
+    const uri = recording.getURI();
+    setRecording(null);
+
+    const formData = new FormData();
+    formData.append("audio", {
+      uri,
+      name: "query.wav",
+      type: "audio/wav",
+    });
+
+    const res = await fetch("http://YOUR_SERVER_IP:8000/ask-cfo", {
+      method: "POST",
+      body: formData,
+    });
+    const arrayBuffer = await res.arrayBuffer();
+    const soundObj = await Audio.Sound.createAsync({
+      uri: `data:audio/mp3;base64,${Buffer.from(arrayBuffer).toString("base64")}`,
+    });
+    soundObj.sound.playAsync();
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+      <Button
+        title={recording ? "Stop & Send" : "Record"}
+        onPress={recording ? stopAndSend : startRecording}
+      />
+    </View>
+  );
+}

--- a/examples/voice-cfo/server/main.py
+++ b/examples/voice-cfo/server/main.py
@@ -1,0 +1,50 @@
+import io
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import StreamingResponse
+from openai import OpenAI
+
+app = FastAPI()
+client = OpenAI()
+
+
+def check_availability(query: str) -> str:
+    """Placeholder for reservation lookup."""
+    # In a real app this would query your reservation DB or API.
+    return "Reservations are wide open."  # dummy response
+
+
+def format_cfo_response(question: str, availability: str) -> str:
+    return f"{availability} You asked: {question}"
+
+
+@app.post("/ask-cfo")
+async def ask_cfo(audio: UploadFile = File(...)):
+    # 1. speech to text
+    transcription = client.audio.transcriptions.create(
+        model="gpt-4o-mini-transcribe",
+        file=audio.file,
+    )
+    question_text = transcription.text
+
+    # 2. lookup reservation data
+    availability = check_availability(question_text)
+
+    # 3. CFO-style reply
+    cfo_response = client.responses.create(
+        model="gpt-4o",
+        input=[
+            {"role": "system", "content": "You are a CFO who can handle reservation queries concisely."},
+            {"role": "user", "content": format_cfo_response(question_text, availability)},
+        ],
+    )
+    answer_text = cfo_response.output_text
+
+    # 4. text to speech
+    speech = client.audio.speech.create(
+        model="gpt-4o-mini-tts",
+        voice="alloy",
+        input=answer_text,
+    )
+
+    # 5. stream back to client
+    return StreamingResponse(io.BytesIO(speech.audio), media_type="audio/mpeg")

--- a/examples/voice-cfo/server/requirements.txt
+++ b/examples/voice-cfo/server/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+openai


### PR DESCRIPTION
## Summary
- add FastAPI server example for CFO-style reservation voice responses
- add React Native mobile client to record and play CFO voice answers
- document setup and usage for the voice AI CFO example

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check` *(fails: many existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c0b4f718833385224f56d7b5a6c0