### PR TITLE
Fix reservation property selection initialization

### DIFF
--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -700,9 +700,11 @@ async function connectToAPI() {
         const allowed = properties.map((p) => p.id);
         if (!propertiesInitialized.current) {
           propertiesInitialized.current = true;
-          return prev.length === 0
-            ? allowed
-            : prev.filter((id) => allowed.includes(id));
+          if (prev.length === 0) {
+            return allowed;
+          }
+          const next = prev.filter((id) => allowed.includes(id));
+          return next.length > 0 ? next : allowed;
         }
         if (prev.length === 0) return prev;
         const next = prev.filter((id) => allowed.includes(id));


### PR DESCRIPTION
## Summary
- ensure the reservations tab defaults to the full set of Supabase properties on first load
- avoid leaving the selected property list empty when demo IDs don't intersect with live data

## Testing
- pnpm lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9d28b28c8333be4a7c1089f048dc