### PR TITLE
Align dashboard cash flow KPI with cash flow report

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,8 +105,13 @@ const classifyPLAccount = (accountType, reportCategory, accountName) => {
 };
 
 // Cash Flow Classification using the same logic as cash-flow page
-const classifyCashFlowTransaction = (accountType) => {
+const classifyCashFlowTransaction = (accountType, reportCategory) => {
   const typeLower = accountType?.toLowerCase() || "";
+  const categoryLower = reportCategory?.toLowerCase() || "";
+
+  if (categoryLower === "transfer") {
+    return "transfer";
+  }
 
   // Operating activities - Income and Expenses
   if (
@@ -767,42 +772,44 @@ export default function FinancialOverviewPage() {
     };
   };
 
-  // Process cash flow transactions EXACTLY like the cash-flow page (offsets method)
-const processCashFlowTransactions = (transactions: any[]) => {
-  const toNum = (v: any) => (v === null || v === undefined || v === "" ? 0 : Number(v));
-  const isTransferRC = (rc: any) => String(rc ?? "").toLowerCase() === "transfer";
+  // Process cash flow transactions to mirror the cash-flow page buckets while
+  // deriving net cash flow directly from consolidated bank activity
+  const processCashFlowTransactions = (transactions: any[]) => {
+    const toNum = (v: any) => (v === null || v === undefined || v === "" ? 0 : Number(v));
+    const isTransferRC = (rc: any) => String(rc ?? "").toLowerCase() === "transfer";
 
-  // 1) Find entries that touched cash (Bank) — exclude transfers
-  const cashEntryNumbers = new Set(
-    (transactions || [])
-      .filter((t) => t.is_cash_account === true && !isTransferRC(t.report_category))
-      .map((t) => t.entry_number)
-  );
+    const cashLines = (transactions || []).filter(
+      (t) => t?.is_cash_account === true && !isTransferRC(t.report_category)
+    );
 
-  // 2) Use ONLY non-cash (offset) lines from those entries — exclude transfers
-  const offsets = (transactions || []).filter(
-    (t) =>
-      t.is_cash_account === false &&
-      cashEntryNumbers.has(t.entry_number) &&
-      !isTransferRC(t.report_category)
-  );
+    const cashEntryNumbers = new Set(cashLines.map((t) => t.entry_number));
 
-  // 3) Sum cash effect by bucket (credit − debit)
-  let operatingCashFlow = 0;
-  let investingCashFlow = 0;
-  let financingCashFlow = 0;
+    const offsets = (transactions || []).filter(
+      (t) =>
+        t?.is_cash_account === false &&
+        cashEntryNumbers.has(t.entry_number) &&
+        !isTransferRC(t.report_category)
+    );
 
-  for (const tx of offsets) {
-    const cashEffect = toNum(tx.credit) - toNum(tx.debit); // authoritative sign
-    const bucket = classifyCashFlowTransaction(tx.account_type, tx.report_category);
-    if (bucket === "operating") operatingCashFlow += cashEffect;
-    else if (bucket === "investing") investingCashFlow += cashEffect;
-    else if (bucket === "financing") financingCashFlow += cashEffect;
-  }
+    let operatingCashFlow = 0;
+    let investingCashFlow = 0;
+    let financingCashFlow = 0;
 
-  const netCashFlow = operatingCashFlow + investingCashFlow + financingCashFlow;
-  return { operatingCashFlow, financingCashFlow, investingCashFlow, netCashFlow };
-};
+    for (const tx of offsets) {
+      const cashEffect = toNum(tx.credit) - toNum(tx.debit);
+      const bucket = classifyCashFlowTransaction(tx.account_type, tx.report_category);
+      if (bucket === "operating") operatingCashFlow += cashEffect;
+      else if (bucket === "investing") investingCashFlow += cashEffect;
+      else if (bucket === "financing") financingCashFlow += cashEffect;
+    }
+
+    const netCashFlow = cashLines.reduce(
+      (sum, tx) => sum + (toNum(tx.debit) - toNum(tx.credit)),
+      0,
+    );
+
+    return { operatingCashFlow, financingCashFlow, investingCashFlow, netCashFlow };
+  };
 
   // Get property performance breakdown
   const getPropertyBreakdown = (transactions) => {


### PR DESCRIPTION
## Summary
- update the cash flow classifier to ignore transfer lines when bucketing activity
- derive the dashboard cash flow KPI from consolidated bank account debits minus credits while keeping activity buckets in sync with the cash flow view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7ec4f844833386b53a6946f3b404