### PR TITLE
Improve revenue detection heuristics for P&L classification

### DIFF
--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -459,22 +459,42 @@ export default function FinancialsPage() {
 
     if (isCashAccount || isTransfer) return null;
 
-    // INCOME ACCOUNTS - Based on account_type
-    const isIncomeAccount =
-      typeLower === "income" ||
-      typeLower === "other income" ||
-      typeLower.includes("income") ||
-      typeLower.includes("revenue");
-
-    // EXPENSE ACCOUNTS - Based on account_type
-    const isExpenseAccount =
+    // Look for strong expense signals first so mixed labels like "Income Tax Expense"
+    // are still treated as expenses.
+    const hasExpenseSignal =
+      typeLower === "expense" ||
       typeLower === "expenses" ||
       typeLower === "other expense" ||
       typeLower === "cost of goods sold" ||
-      typeLower.includes("expense");
+      typeLower.includes("expense") ||
+      typeLower.includes("cogs") ||
+      categoryLower.includes("expense") ||
+      categoryLower.includes("cost of goods") ||
+      categoryLower.includes("cogs") ||
+      categoryLower.includes("payroll") ||
+      nameLower.includes("expense") ||
+      nameLower.includes("cost of goods");
 
-    if (isIncomeAccount) return "INCOME";
-    if (isExpenseAccount) return "EXPENSES";
+    if (hasExpenseSignal) return "EXPENSES";
+
+    // Then fall back to income detection so we can include revenue accounts that
+    // may be stored under non-standard account types but have income metadata.
+    const hasIncomeSignal =
+      typeLower === "income" ||
+      typeLower === "other income" ||
+      typeLower.includes("income") ||
+      typeLower.includes("revenue") ||
+      categoryLower.includes("income") ||
+      categoryLower.includes("revenue") ||
+      categoryLower.includes("sales") ||
+      categoryLower.includes("short term rental") ||
+      categoryLower.includes("rental income") ||
+      nameLower.includes("income") ||
+      nameLower.includes("revenue") ||
+      nameLower.includes("short term rental") ||
+      nameLower.includes("airbnb");
+
+    if (hasIncomeSignal) return "INCOME";
 
     return null; // Not a P&L account (likely Balance Sheet account)
   };


### PR DESCRIPTION
## Summary
- expand the profit and loss classifier to check for expense signals before income detection
- add broader income keyword support so Airbnb and other rental revenue accounts are included in financial totals
- keep the financial overview and financials pages in sync with the enhanced classification logic

## Testing
- pnpm lint *(fails due to pre-existing lint warnings and type errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68df8b7d996483339804924c883c4fed