### PR TITLE
Route other expense accounts to operating cash flow

### DIFF
--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -613,6 +613,7 @@ export default function CashFlowPage() {
     if (
       typeLower === "income" ||
       typeLower === "other income" ||
+      typeLower === "other expense" ||
       typeLower === "expenses" ||
       typeLower === "expense" ||
       typeLower === "cost of goods sold" ||

--- a/src/app/mobile-dashboard/page.tsx
+++ b/src/app/mobile-dashboard/page.tsx
@@ -460,6 +460,7 @@ export default function EnhancedMobileDashboard() {
     if (
       typeLower === "income" ||
       typeLower === "other income" ||
+      typeLower === "other expense" ||
       typeLower === "expenses" ||
       typeLower === "expense" ||
       typeLower === "cost of goods sold" ||


### PR DESCRIPTION
## Summary
- treat "other expense" account types as operating cash flow in the cash flow view
- mirror the same classification update in the mobile dashboard cash flow summary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfdde000108333a07d06f286fa52d0