### PR TITLE
Ensure cash flow details include memo and payee information

### DIFF
--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -877,7 +877,9 @@ export default function CashFlowPage() {
     // Attempt to use the cash_related_offsets view
     let viewQuery = supabase
       .from("cash_related_offsets")
-      .select("entry_number,date,class,account,account_type,report_category,debit,credit,cash_effect,cash_bank_account")
+      .select(
+        "entry_number,date,class,account,account_type,report_category,debit,credit,cash_effect,cash_bank_account,memo,name,customer,vendor",
+      )
       .gte("date", startDate)
       .lte("date", endDate)
 
@@ -943,9 +945,11 @@ export default function CashFlowPage() {
 
     if (entryNumbers.length === 0) return []
 
-    let offsetQuery = supabase
+    const offsetQuery = supabase
       .from("journal_entry_lines")
-      .select("entry_number,date,class,account,account_type,report_category,debit,credit")
+      .select(
+        "entry_number,date,class,account,account_type,report_category,debit,credit,memo,name,customer,vendor",
+      )
       .in("entry_number", entryNumbers)
       .eq("is_cash_account", false)
 


### PR DESCRIPTION
## Summary
- request memo and name columns when loading cash_related_offsets data so cash flow details can display payee and memo
- include the same fields in the manual journal_entry_lines fallback query to keep parity across data sources

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdefa8d8c833396126dac9b63721c