### PR TITLE
Update cash flow and P&L detail modals to use name column

### DIFF
--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -3244,7 +3244,7 @@ export default function CashFlowPage() {
                         Date
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Payee/Customer
+                        Name
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Memo

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -2853,7 +2853,7 @@ export default function FinancialsPage() {
                         Date
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Payee/Customer
+                        Name
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Memo
@@ -2897,7 +2897,7 @@ export default function FinancialsPage() {
                           <td className="px-6 py-4 text-sm text-gray-900">
                             {transaction.name ||
                               transaction.vendor ||
-                              transaction.class ||
+                              transaction.employee ||
                               "N/A"}
                           </td>
                           <td className="px-6 py-4 text-sm text-gray-500">


### PR DESCRIPTION
## Summary
- rename the Payee/Customer column label in cash flow and P&L detail modals to Name
- prefer the Supabase-provided name field when displaying transaction details, with fallbacks to vendor or employee where applicable

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68dfe45636b48333b35357fac87420b2